### PR TITLE
fix typo in page titles :p

### DIFF
--- a/layout/base.html
+++ b/layout/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-	<title>{% block title %}{{ resource.meta.title }}{% endblock %} - Hackespaces.be</title>
+	<title>{% block title %}{{ resource.meta.title }}{% endblock %} - Hackerspaces.be</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 	<script type="text/javascript" src="https://www.google.com/jsapi"></script>


### PR DESCRIPTION
Page titles say "Hackespaces.be" instead of "Hacke_r_spaces.be"...
